### PR TITLE
Removing description tag from installation XML

### DIFF
--- a/ga-IE_joomla_installation/installation/language/ga-IE/ga-IE.xml
+++ b/ga-IE_joomla_installation/installation/language/ga-IE/ga-IE.xml
@@ -6,7 +6,6 @@
 	<author>Irish translation team</author>
 	<copyright>Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-	<description>Irish installation language</description>
 	<files><filename>ga-IE.ini</filename></files>
 	<metadata>
 		<name>Gaeilge (Éire)</name>


### PR DESCRIPTION
We don't use that tag anywhere in installation and thus it got removed from all installation language XML files. See https://github.com/joomla/joomla-cms/pull/8546